### PR TITLE
Fix variable setup and add rho_xy

### DIFF
--- a/programs/single_dimer_chemotactic_cell.f90
+++ b/programs/single_dimer_chemotactic_cell.f90
@@ -28,8 +28,6 @@ program setup_single_dimer
   type(lj_params_t) :: colloid_lj
   type(lj_params_t) :: walls_colloid_lj
 
-  type(profile_t) :: tz
-  type(histogram_t) :: rhoz
   type(profile_t) :: vx
 
   integer :: rho
@@ -61,7 +59,6 @@ program setup_single_dimer
   integer(HID_T) :: box_group
 
   type(PTo) :: config
-  integer(c_int64_t) :: seed
   integer :: i, L(3),  n_threads
   integer :: j, k, m
   
@@ -99,6 +96,7 @@ program setup_single_dimer
 
   T = PTread_d(config, 'T')
   d = PTread_d(config, 'd')
+  order = PTread_l(config, 'order')
 
   wall_v = 0
   wall_t = [T, T]
@@ -220,13 +218,12 @@ program setup_single_dimer
   call solvent_cells%init(L, 1.d0,has_walls = .true.)
 
   colloids% pos(3,:) = solvent_cells% edges(3)/2.d0
-  order = .false.!PTread_l(config, 'order')
   if (order) then
-     colloids% pos(1,1) = sigma_C*2**(1.d0/6.d0)+0.1d0
+     colloids% pos(1,1) = sigma_C*2**(1.d0/6.d0) + 1
      colloids% pos(1,2) = colloids% pos(1,1) + d
      colloids% pos(2,:) = solvent_cells% edges(2)/2.d0 + 1.5d0*maxval([sigma_C,sigma_N])
   else
-     colloids% pos(1,2) = sigma_N*2**(1.d0/6.d0)+0.1d0
+     colloids% pos(1,2) = sigma_N*2**(1.d0/6.d0) + 1
      colloids% pos(1,1) = colloids% pos(1,2) + d
      colloids% pos(2,:) = solvent_cells% edges(2)/2.d0 + 1.5d0*maxval([sigma_C,sigma_N])
   end if

--- a/programs/single_dimer_chemotactic_cell.f90
+++ b/programs/single_dimer_chemotactic_cell.f90
@@ -19,6 +19,7 @@ program setup_single_dimer
 
   type(threefry_rng_t), allocatable :: state(:)
   
+  integer, parameter :: N_species = 3
 
   type(cell_system_t) :: solvent_cells
   type(particle_system_t) :: solvent
@@ -111,8 +112,8 @@ program setup_single_dimer
   sigma_C = PTread_d(config, 'sigma_C')
   sigma_N = PTread_d(config, 'sigma_N')
 
-  epsilon(:,1) = PTread_dvec(config, 'epsilon_C', 3)
-  epsilon(:,2) = PTread_dvec(config, 'epsilon_N', 3)
+  epsilon(:,1) = PTread_dvec(config, 'epsilon_C', N_species)
+  epsilon(:,2) = PTread_dvec(config, 'epsilon_N', N_species)
 
   sigma(:,1) = sigma_C
   sigma(:,2) = sigma_N
@@ -142,7 +143,7 @@ program setup_single_dimer
   mass(2) = rho * sigma_N**3 * 4 * 3.14159265/3
   write(*,*) 'mass =', mass
 
-  call solvent% init(N,3) !there will be 3 species of solvent particles
+  call solvent% init(N,N_species)
 
   call colloids% init(2,2, mass) !there will be 2 species of colloids
 

--- a/programs/single_dimer_chemotactic_cell.f90
+++ b/programs/single_dimer_chemotactic_cell.f90
@@ -67,6 +67,7 @@ program setup_single_dimer
   double precision :: g(3) !gravity
   logical :: fixed, on_track, stopped, order
   integer :: bufferlength
+  integer :: steps_fixed
   fixed = .true.
   on_track = .true.
   stopped = .false.
@@ -105,7 +106,7 @@ program setup_single_dimer
   N_MD_steps = PTread_i(config, 'N_MD')
   dt = tau / N_MD_steps
   N_loop = PTread_i(config, 'N_loop')
-
+  steps_fixed = PTread_i(config, 'steps_fixed')
   
   sigma_C = PTread_d(config, 'sigma_C')
   sigma_N = PTread_d(config, 'sigma_N')
@@ -400,7 +401,7 @@ program setup_single_dimer
      call dimer_io%velocity%append(colloids%vel)
      call dimer_io%image%append(colloids%image)
 
-     if (i .gt. 2000) then
+     if (i >= steps_fixed) then
         fixed = .false.
      end if
      


### PR DESCRIPTION
Fix the initialization of `order` via the config file and set the number of steps for the fixed dimer from the config file.

Compute the species- and time-dependent xy density `rho_xy` and store it in the H5MD file.
